### PR TITLE
Default Setting Should have Debug Off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(PLATFORM_SPECIFIC_LIBS pthread)
 
-set(CMAKE_BUILD_TYPE Debug)
-
 add_subdirectory(external/abieos EXCLUDE_FROM_ALL)
 add_subdirectory(external/leap/libraries/chainbase EXCLUDE_FROM_ALL)
 add_subdirectory(external/leap/libraries/appbase EXCLUDE_FROM_ALL)


### PR DESCRIPTION
When starting off the pinned build I would get the following error messages. This was resolved by removing `set(CMAKE_BUILD_TYPE Debug)` so the environment matched. This PR requests this change to be the default.

Resolves #26 

```
CHAINBASE: "receiver-state" database was created with a chainbase from a different environment
Current compiler environment:
       Compiler: Clang 11.0.1
          Debug: Yes
             OS: Linux
           Arch: x86_64
          Boost: 1.80.0
DB created with compiler environment:
       Compiler: Clang 11.0.1
          Debug: No
             OS: Linux
           Arch: x86_64
          Boost: 1.80.0
warn  2023-07-03T20:52:34.178 chronicle receiver_plugin.cpp:1807      plugin_initialize    ] 13 N5boost10wrapexceptINSt3__112system_errorEEE: Database incompatible; All environment parameters must match
rethrow Database incompatible; All environment parameters must match: 
    {"what":"Database incompatible; All environment parameters must match"}
    chronicle-recei  receiver_plugin.cpp:1807 plugin_initialize
```